### PR TITLE
log: shorten __FILE__ debug output

### DIFF
--- a/log.h
+++ b/log.h
@@ -19,6 +19,7 @@
 #define _LOG_H_
 
 #include <sys/types.h>
+#include <libgen.h>
 #include <unistd.h>
 
 extern int dbg_level;
@@ -38,10 +39,10 @@ extern int use_syslog;
 #define MSG_INFO	3
 #define MSG_DEBUG	4
 
-#define ERROR(mtype, msg, ...) write_message(mtype, MSG_ERROR, "[%d %s:%u] error: " msg, getpid(), __FILE__, __LINE__, ## __VA_ARGS__)
-#define  WARN(mtype, msg, ...) write_message(mtype, MSG_WARN,  "[%d %s:%u]  warn: " msg, getpid(), __FILE__, __LINE__, ## __VA_ARGS__)
-#define  INFO(mtype, msg, ...) write_message(mtype, MSG_INFO,  "[%d %s:%u]  info: " msg, getpid(), __FILE__, __LINE__, ## __VA_ARGS__)
-#define DEBUG(mtype, msg, ...) write_message(mtype, MSG_DEBUG, "[%d %s:%u] debug: " msg, getpid(), __FILE__, __LINE__, ## __VA_ARGS__)
+#define ERROR(mtype, msg, ...) write_message(mtype, MSG_ERROR, "[%d %s:%u] error: " msg, getpid(), basename(__FILE__), __LINE__, ## __VA_ARGS__)
+#define  WARN(mtype, msg, ...) write_message(mtype, MSG_WARN,  "[%d %s:%u]  warn: " msg, getpid(), basename(__FILE__), __LINE__, ## __VA_ARGS__)
+#define  INFO(mtype, msg, ...) write_message(mtype, MSG_INFO,  "[%d %s:%u]  info: " msg, getpid(), basename(__FILE__), __LINE__, ## __VA_ARGS__)
+#define DEBUG(mtype, msg, ...) write_message(mtype, MSG_DEBUG, "[%d %s:%u] debug: " msg, getpid(), basename(__FILE__), __LINE__, ## __VA_ARGS__)
 
 void write_message(const unsigned int, const int, const char*, ...);
 int open_udplog(char *, int );


### PR DESCRIPTION
Makes the debug output much readable because the __FILE__ displays the full patch when cross compiling.
Now it will simply display the basename of the __FILE__ leaving path out.